### PR TITLE
DBVIS-9420 Design flaw in editor syntax handling

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -567,6 +567,20 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 		this.syntaxStyle = "text/unknown"; // TODO: Make me public?
 	}
 
+	/**
+	 * Sets the syntax style being used for syntax highlighting in this
+	 * document. You should call this method if you've created a custom token
+	 * maker for a language not normally supported by <code>RSyntaxTextArea</code>.
+	 *
+	 * @param tokenMaker The new token maker to use.
+	 * @param styleKey  The new style to use, such as {@link SyntaxConstants#SYNTAX_STYLE_JAVA}.
+	 * @see #setSyntaxStyle(TokenMaker)
+	 */
+	public void setSyntaxStyle(TokenMaker tokenMaker, String styleKey) {
+		this.tokenMaker = tokenMaker;
+		updateSyntaxHighlightingInformation();
+		this.syntaxStyle = styleKey;
+	}
 
 	/**
 	 * Sets the token maker factory used by this document.

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -590,27 +590,6 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 		this.syntaxStyle = styleKey;
 	}
 
-	// ------------------------
-	// ADDITIONS FOR DBVIS-9154
-	// ------------------------
-
-	/**
-	 * @return current {@link TokenMaker} or <code>null</code>
-	 */
-	public TokenMaker getTokenMaker() {
-		return tokenMaker;
-	}
-
-	/**
-	 * @return current {@link TokenMakerFactory} or <code>null</code>
-	 */
-	public TokenMakerFactory getTokenMakerFactory() {
-		return tokenMakerFactory;
-	}
-	// ----------------------------
-	// END ADDITIONS FOR DBVIS-9154
-	// ----------------------------
-
 	/**
 	 * Sets the token maker factory used by this document.
 	 *

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocument.java
@@ -390,6 +390,14 @@ public class RSyntaxDocument extends RDocument implements Iterable<Token>,
 		return syntaxStyle;
 	}
 
+	/**
+	 * Returns the {@link TokenMaker} being used.
+	 *
+	 * @return current {@link TokenMaker} (or <code>null</code>)
+	 */
+	public TokenMaker getTokenMaker() {
+		return tokenMaker;
+	}
 
 	/**
 	 * Returns a token list for the specified segment of text representing

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -12,12 +12,11 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
 
 import javax.swing.*;
+import javax.swing.Timer;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.CaretListener;
 import javax.swing.event.HyperlinkEvent;
@@ -3060,15 +3059,21 @@ private boolean fractionalFontMetricsEnabled;
 	 * @see SyntaxConstants
 	 */
 	public void setSyntaxEditingStyle(TokenMaker tokenMaker, String styleKey) {
-		((RSyntaxDocument)getDocument()).setSyntaxStyle(tokenMaker, styleKey);
-
 		if (styleKey==null) {
 			styleKey = SYNTAX_STYLE_NONE;
 		}
+
 		if (!styleKey.equals(syntaxStyleKey)) {
 			String oldStyle = syntaxStyleKey;
 			syntaxStyleKey = styleKey;
+
+			RSyntaxDocument doc = (RSyntaxDocument)getDocument();
+			if (!(Objects.equals(styleKey, doc.getSyntaxStyle()) && Objects.equals(tokenMaker, doc.getTokenMaker()))) {
+				doc.setSyntaxStyle(tokenMaker, styleKey);
+			}
+
 			firePropertyChange(SYNTAX_STYLE_PROPERTY, oldStyle, styleKey);
+			setActiveLineRange(-1, -1);
 		}
 	}
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -3047,6 +3047,30 @@ private boolean fractionalFontMetricsEnabled;
 
 	}
 
+	/**
+	 * Sets what type of syntax highlighting this editor is doing using a specific {@link TokenMaker}.
+	 * This method fires a property change of type {@link #SYNTAX_STYLE_PROPERTY}.
+	 * You should call this method if you've created a custom token maker for a language
+	 * not normally supported by <code>RSyntaxTextArea</code>.
+	 *
+	 * @param tokenMaker The new token maker to use.
+	 * @param styleKey  The new style to use, such as {@link SyntaxConstants#SYNTAX_STYLE_JAVA}.
+	 * @see #setSyntaxEditingStyle(String)
+	 * @see RSyntaxDocument#setSyntaxStyle(TokenMaker, String)
+	 * @see SyntaxConstants
+	 */
+	public void setSyntaxEditingStyle(TokenMaker tokenMaker, String styleKey) {
+		((RSyntaxDocument)getDocument()).setSyntaxStyle(tokenMaker, styleKey);
+
+		if (styleKey==null) {
+			styleKey = SYNTAX_STYLE_NONE;
+		}
+		if (!styleKey.equals(syntaxStyleKey)) {
+			String oldStyle = syntaxStyleKey;
+			syntaxStyleKey = styleKey;
+			firePropertyChange(SYNTAX_STYLE_PROPERTY, oldStyle, styleKey);
+		}
+	}
 
 	/**
 	 * Sets all the colors used in syntax highlighting to the colors

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocumentTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocumentTest.java
@@ -475,11 +475,14 @@ class RSyntaxDocumentTest {
 		String noStyle = SyntaxConstants.SYNTAX_STYLE_NONE;
 		doc = new RSyntaxDocument(noStyle);
 		Assertions.assertEquals(noStyle, doc.getSyntaxStyle());
+		TokenMaker plainTextTokenMaker = doc.getTokenMaker();
+		Assertions.assertNotNull(plainTextTokenMaker);
 
 		String htmlStyle = SyntaxConstants.SYNTAX_STYLE_HTML;
-		TokenMaker tokenMaker = new HTMLTokenMaker();
-		doc.setSyntaxStyle(tokenMaker, htmlStyle);
+		TokenMaker htmlTokenMaker = new HTMLTokenMaker();
+		doc.setSyntaxStyle(htmlTokenMaker, htmlStyle);
 		Assertions.assertEquals(htmlStyle, doc.getSyntaxStyle());
+		Assertions.assertEquals(htmlTokenMaker, doc.getTokenMaker());
 	}
 
 	@Test

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocumentTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxDocumentTest.java
@@ -469,6 +469,18 @@ class RSyntaxDocumentTest {
 
 	}
 
+	@Test
+	void testSetSyntaxStyle_CustomTokenMakerStyle() {
+
+		String noStyle = SyntaxConstants.SYNTAX_STYLE_NONE;
+		doc = new RSyntaxDocument(noStyle);
+		Assertions.assertEquals(noStyle, doc.getSyntaxStyle());
+
+		String htmlStyle = SyntaxConstants.SYNTAX_STYLE_HTML;
+		TokenMaker tokenMaker = new HTMLTokenMaker();
+		doc.setSyntaxStyle(tokenMaker, htmlStyle);
+		Assertions.assertEquals(htmlStyle, doc.getSyntaxStyle());
+	}
 
 	@Test
 	void testSetTokenMakerFactory() {

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.Scanner;
 
 import org.fife.ui.SwingRunnerExtension;
+import org.fife.ui.rsyntaxtextarea.modes.HTMLTokenMaker;
 import org.fife.ui.rsyntaxtextarea.modes.JavaTokenMaker;
 import org.fife.ui.rsyntaxtextarea.parser.AbstractParser;
 import org.fife.ui.rsyntaxtextarea.parser.ParseResult;
@@ -710,6 +711,20 @@ class RSyntaxTextAreaTest extends AbstractRSyntaxTextAreaTest {
 		Assertions.assertEquals(SyntaxConstants.SYNTAX_STYLE_JAVA, textArea.getSyntaxEditingStyle());
 	}
 
+	@Test
+	void testSyntaxEditingStyleTokenMaker() {
+		RSyntaxTextArea textArea = new RSyntaxTextArea();
+
+		String noStyle = SyntaxConstants.SYNTAX_STYLE_NONE;
+		Assertions.assertEquals(noStyle, textArea.getSyntaxEditingStyle());
+		Assertions.assertEquals(noStyle, ((RSyntaxDocument)textArea.getDocument()).getSyntaxStyle());
+
+		String htmlStyle = SyntaxConstants.SYNTAX_STYLE_HTML;
+		TokenMaker tokenMaker = new HTMLTokenMaker();
+		textArea.setSyntaxEditingStyle(tokenMaker, htmlStyle);
+		Assertions.assertEquals(htmlStyle, textArea.getSyntaxEditingStyle());
+		Assertions.assertEquals(htmlStyle, ((RSyntaxDocument)textArea.getDocument()).getSyntaxStyle());
+	}
 
 	/**
 	 * In {@code RSyntaxTextArea}, the code path {@code setDocument()} ->

--- a/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
+++ b/RSyntaxTextArea/src/test/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextAreaTest.java
@@ -774,6 +774,12 @@ class RSyntaxTextAreaTest extends AbstractRSyntaxTextAreaTest {
 		RSyntaxTextArea textArea = createTextArea();
 		textArea.setSyntaxEditingStyle(null);
 		Assertions.assertEquals(SyntaxConstants.SYNTAX_STYLE_NONE, textArea.getSyntaxEditingStyle());
+
+		textArea.setSyntaxEditingStyle(null, null);
+		Assertions.assertEquals(SyntaxConstants.SYNTAX_STYLE_NONE, textArea.getSyntaxEditingStyle());
+		RSyntaxDocument doc = (RSyntaxDocument) textArea.getDocument();
+		Assertions.assertEquals(SyntaxConstants.SYNTAX_STYLE_NONE, doc.getSyntaxStyle());
+		Assertions.assertNotNull(doc.getTokenMaker());
 	}
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaVersion=11
-version=3.4.0-240617
+version=3.4.0-240618
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaVersion=11
-version=3.4.0-240521
+version=3.4.0-240614
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaVersion=11
-version=3.4.0-240614
+version=3.4.0-240617
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
- update from branch #548 (where PR for RSTA lives):
    - add RSyntaxDocument.getTokenMaker()
    - remove proprietary changes tagged with DBVIS-9154
    - bump version number to 240617