### PR TITLE
Dbvis 9439 allow font and fontmetrics per token

### DIFF
--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractTokenViewModelConverter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/AbstractTokenViewModelConverter.java
@@ -133,7 +133,7 @@ public abstract class AbstractTokenViewModelConverter implements TokenViewModelC
 
 		while (token != null && token.isPaintable()) {
 
-			FontMetrics fm = textArea.getFontMetricsForTokenType(token.getType());
+			FontMetrics fm = textArea.getFontMetricsForToken(token);
 			if (fm == null) {
 				return rect; // Don't return null as things will error.
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/BufferedTokenViewModelConverter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/BufferedTokenViewModelConverter.java
@@ -38,7 +38,7 @@ public class BufferedTokenViewModelConverter extends AbstractTokenViewModelConve
 
 	@Override
 	protected int getTokenListOffset() {
-		this.fm = textArea.getFontMetricsForTokenType(token.getType());
+		this.fm = textArea.getFontMetricsForToken(token);
 
 		// loop over text in token
 		int begin = token.textOffset;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenPainter.java
@@ -105,8 +105,8 @@ public class DefaultTokenPainter implements TokenPainter { // DBVIS-5813 Make cl
 		Color fg = useSTC ? host.getSelectedTextColor() :
 			host.getForegroundForToken(token);
 		Color bg = selected ? null : host.getBackgroundForToken(token);
-		g.setFont(host.getFontForTokenType(token.getType()));
-		FontMetrics fm = host.getFontMetricsForTokenType(token.getType());
+		g.setFont(host.getFontForToken(token));
+		FontMetrics fm = host.getFontMetricsForToken(token);
 
 		for (int i=textOffs; i<end; i++) {
 			switch (text[i]) {
@@ -218,7 +218,7 @@ public class DefaultTokenPainter implements TokenPainter { // DBVIS-5813 Make cl
 		}
 
 		// Get the length of a tab.
-		FontMetrics fm = host.getFontMetricsForTokenType(token.getType());
+		FontMetrics fm = host.getFontMetricsForToken(token);
 		int tabSize = host.getTabSize();
 		if (tabBuf==null || tabBuf.length<tabSize) {
 			tabBuf = new char[tabSize];

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenViewModelConverter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/DefaultTokenViewModelConverter.java
@@ -51,7 +51,7 @@ public class DefaultTokenViewModelConverter implements TokenViewModelConverter {
 
 		while (token != null && token.isPaintable()) {
 
-			fm = textArea.getFontMetricsForTokenType(token.getType());
+		        fm = textArea.getFontMetricsForToken(token);
 			char[] text = token.text;
 			int start = token.textOffset;
 			int end = start + token.textCount;
@@ -95,7 +95,7 @@ public class DefaultTokenViewModelConverter implements TokenViewModelConverter {
 
 		while (token != null && token.isPaintable()) {
 
-			fm = textArea.getFontMetricsForTokenType(token.getType());
+		        fm = textArea.getFontMetricsForToken(token);
 			if (fm == null) {
 				return rect; // Don't return null as things will error.
 			}

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/RSyntaxTextArea.java
@@ -1183,6 +1183,17 @@ private boolean fractionalFontMetricsEnabled;
 	/**
 	 * Returns the font for tokens of the specified type.
 	 *
+	 * @param token the token.
+	 * @return The font to use for that token type.
+	 * @see #getFontMetricsForTokenType(int)
+	 */
+	public Font getFontForToken(Token token) {
+	        return getFontForTokenType(token.getType());
+	}
+
+	/**
+	 * Returns the font for tokens of the specified type.
+	 *
 	 * @param type The type of token.
 	 * @return The font to use for that token type.
 	 * @see #getFontMetricsForTokenType(int)
@@ -1192,6 +1203,16 @@ private boolean fractionalFontMetricsEnabled;
 		return f!=null ? f : getFont();
 	}
 
+	/**
+	 * Returns the font metrics for the given token.
+	 *
+	 * @param token the Token
+	 * @return The font metrics to use for that tokenx.
+	 * @see #getFontForTokenType(int)
+	 */
+	public FontMetrics getFontMetricsForToken(Token token) {
+	        return getFontMetricsForTokenType(token.getType());
+	}
 
 	/**
 	 * Returns the font metrics for tokens of the specified type.
@@ -1202,7 +1223,7 @@ private boolean fractionalFontMetricsEnabled;
 	 */
 	public FontMetrics getFontMetricsForTokenType(int type) {
 		FontMetrics fm = syntaxScheme.getStyle(type).fontMetrics;
-		return fm!=null ? fm : defaultFontMetrics;
+		return  fm!=null ? fm : defaultFontMetrics;
 	}
 
 

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/TokenImpl.java
@@ -509,7 +509,7 @@ public class TokenImpl implements Token {
 	public int getOffsetBeforeX(RSyntaxTextArea textArea, TabExpander e,
 							float startX, float endBeforeX) {
 
-		FontMetrics fm = textArea.getFontMetricsForTokenType(getType());
+	        FontMetrics fm = textArea.getFontMetricsForToken(this);
 		int i = textOffset;
 		int stop = i + textCount;
 		float x = startX;
@@ -565,7 +565,7 @@ public class TokenImpl implements Token {
 	public float getWidthUpTo(int numChars, RSyntaxTextArea textArea,
 			TabExpander e, float x0) {
 		float width = x0;
-		FontMetrics fm = textArea.getFontMetricsForTokenType(getType());
+		FontMetrics fm = textArea.getFontMetricsForToken(this);
 		if (fm != null) {
 			int w;
 			int currentStart = textOffset;

--- a/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
+++ b/RSyntaxTextArea/src/main/java/org/fife/ui/rsyntaxtextarea/VisibleWhitespaceTokenPainter.java
@@ -65,8 +65,8 @@ public class VisibleWhitespaceTokenPainter extends DefaultTokenPainter { // DBVI
 		Color fg = useSTC ? host.getSelectedTextColor() :
 			host.getForegroundForToken(token);
 		Color bg = selected ? null : host.getBackgroundForToken(token);
-		g.setFont(host.getFontForTokenType(token.getType()));
-		FontMetrics fm = host.getFontMetricsForTokenType(token.getType());
+		g.setFont(host.getFontForToken(token));
+		FontMetrics fm = host.getFontMetricsForToken(token);
 
 		int ascent = fm.getAscent();
 		int height = fm.getHeight();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaVersion=11
-version=3.4.0-240618
+version=3.4.0-240625
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
* DBVIS-9439 allow font and fontmetrics per token and use those methods instead of the versions that use Token type.